### PR TITLE
Bring back Docker BUILDPLATFORM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-FROM golang:1.23-alpine3.20 AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.23-alpine3.20 AS builder
 ARG RELEASE_VERSION=devel
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
The builds are taking longer since it was removed, bringing it back to see if that fixes the issue.