### PR TITLE
Run single job for building docker and pushing to multiple regitries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,27 +110,25 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
-    # if: ${{ github.event_name != 'pull_request' }}
     needs: test
-    strategy:
-      matrix:
-        include:
-          # empty registry for DockerHub
-          - registry: ""
-            username: DOCKERHUB_USERNAME
-            password: DOCKERHUB_TOKEN
-            base-repo: zmazay/s3sync-service
-          - registry: quay.io
-            username: QUAY_USERNAME
-            password: QUAY_TOKEN
-            base-repo: quay.io/s3sync-service/s3sync-service
-          - registry: ghcr.io
-            username: GHCR_REGISTRY_USERNAME
-            password: GITHUB_TOKEN
-            base-repo: ghcr.io/${{ github.repository }}
     steps:
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            zmazay/s3sync-service
+            quay.io/s3sync-service/s3sync-service
+            ghcr.io/${{ github.repository }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
 
       - name: Chechout
         uses: actions/checkout@v4
@@ -141,19 +139,32 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to registry
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          registry: ${{ matrix.registry }}
-          username: ${{ secrets[matrix.username] }}
-          password: ${{ secrets[matrix.password] }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: "quay.io"
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: "ghcr.io"
+          username: ${{ secrets.GHCR_REGISTRY_USERNAME }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           push: true
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/ppc64le
-          tags: "${{ matrix.base-repo }}:${{ env.GITHUB_REF_SLUG }}"
+          tags: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,8 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/ppc64le
-          tags: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
No need to run matrix builds, the `docker/build-push-action` can push to multiple registries.