### PR TITLE
Set RELEASE_VERSION for docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args:
+            RELEASE_VERSION=${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, try to be as brief and as specific as possible -->

# Description

<!-- Describe your changes in detail, what you trying to achieve with this PR and why -->

Currently, docker builds with `RELEASE_VERSION=devel`, this PR should fix that and set the proper version string.

# Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI update/change

# Pre-flight checklist

- [x] I have performed a self-review of my code
- [ ] The change is covered by tests
- [ ] The documentation is updated accordingly
- [x] PR label set
